### PR TITLE
Add redirects to RLI scenarios to config/routes.rb

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,10 @@
 ETM::Application.routes.draw do
 
+  # Temporary: Redirect RLI scenarios to beta scenarios
+  match '/ser-scenario-2023'                    => redirect { 'http://beta.pro.et-model.com/scenarios/193349' }
+  match '/80-procent-co2-reductiescenario-2050' => redirect { 'http://beta.pro.et-model.com/scenarios/423879' }
+  match '/95-procent-co2-reductiescenario-2050' => redirect { 'http://beta.pro.et-model.com/scenarios/423882' }
+
   # match '/help' => 'articles#index', as: :help
 
   resources :pages,           only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 ETM::Application.routes.draw do
 
   # Temporary: Redirect RLI scenarios to beta scenarios
-  match '/ser-scenario-2023'                    => redirect { 'http://beta.pro.et-model.com/scenarios/193349' }
-  match '/80-procent-co2-reductiescenario-2050' => redirect { 'http://beta.pro.et-model.com/scenarios/423879' }
-  match '/95-procent-co2-reductiescenario-2050' => redirect { 'http://beta.pro.et-model.com/scenarios/423882' }
+  match '/rli/ser-scenario-2023'                    => redirect { 'http://beta.pro.et-model.com/scenarios/193349' }
+  match '/rli/80-procent-co2-reductiescenario-2050' => redirect { 'http://beta.pro.et-model.com/scenarios/423879' }
+  match '/rli/95-procent-co2-reductiescenario-2050' => redirect { 'http://beta.pro.et-model.com/scenarios/423882' }
 
   # match '/help' => 'articles#index', as: :help
 

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -21,4 +21,24 @@ describe 'redirects' do
 
   end
 
+  describe 'RLI scenarios' do
+    context 'RLI ser-scenario-2023' do
+      it 'redirects to beta ETM ser scenario 2023' do
+        get '/rli/ser-scenario-2023'
+        expect(response).to redirect_to "http://beta.pro.et-model.com/scenarios/193349"
+      end
+    end
+    context 'RLI 80% CO2 reductie' do
+      it 'redirects to beta ETM 80% CO2 reductie scenario' do
+        get '/rli/80-procent-co2-reductiescenario-2050'
+        expect(response).to redirect_to "http://beta.pro.et-model.com/scenarios/423879"
+      end
+    end
+    context 'RLI 95% CO2 reductie' do
+      it 'redirects to beta ETM 95% CO2 reductie scenario' do
+        get '/rli/95-procent-co2-reductiescenario-2050'
+        expect(response).to redirect_to "http://beta.pro.et-model.com/scenarios/423882"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds three descriptive URLs to link straight to ET Model beta scenarios. Specs passing. Closes #122 

cc @dennisschoenmakers @AlexanderWirtz 
