### PR TITLE
Add invisible captcha to feedback form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ group :test, :development do
 end
 
 group :development do
+  gem 'letter_opener'
+
   gem 'better_errors'
   gem 'binding_of_caller'
 

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem 'coffee-rails'
 gem 'uglifier'
 gem 'therubyracer'
 
+gem 'invisible_captcha'
+
 gem 'sentry-raven'
 gem 'json', '>= 2.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,8 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    invisible_captcha (1.0.1)
+      rails (>= 4.2)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -339,6 +341,7 @@ DEPENDENCIES
   haml
   http_accept_language
   httparty
+  invisible_captcha
   jquery-rails
   json (>= 2.3)
   launchy

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,8 @@ GEM
     json (2.3.0)
     launchy (2.4.3)
       addressable (~> 2.3)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
     libv8 (3.16.14.19)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -345,6 +347,7 @@ DEPENDENCIES
   jquery-rails
   json (>= 2.3)
   launchy
+  letter_opener
   nokogiri
   pry-rails
   puma

--- a/app/assets/stylesheets/global_style.sass
+++ b/app/assets/stylesheets/global_style.sass
@@ -40,10 +40,10 @@ li
 
 i
   color: #282B36
-  
+
 p.notice
   margin-top: 1em
   text-align: center
   font-size: 20px
   font-weight: 300
-  color: red
+  color: #f44336

--- a/app/assets/stylesheets/pages.sass
+++ b/app/assets/stylesheets/pages.sass
@@ -43,6 +43,11 @@
         padding-left: 0
 
   .feedback_form
+    .notice
+      color: #388e3c
+      text-align: left
+      &.error
+        color: #f44336
     .field
       &__message
         textarea

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,10 @@
 class PagesController < ApplicationController
+  invisible_captcha(
+    only: [:send_feedback],
+    scope: :feedback,
+    honeypot: :country,
+    on_spam: :send_feedback_spam
+  )
 
   def root
     @people = Person.all.sort
@@ -23,6 +29,10 @@ class PagesController < ApplicationController
     FeedbackMailer.feedback_email(feedback_parameters).deliver
     flash[:notice] = I18n.t('contact.feedback_confirm')
     redirect_to action: 'contact'
+  end
+
+  def send_feedback_spam
+    redirect_to contact_url
   end
 
   private

--- a/app/views/pages/_flash_notice.html.haml
+++ b/app/views/pages/_flash_notice.html.haml
@@ -1,3 +1,7 @@
 - if flash[:notice]
   %p.notice= flash[:notice]
   - flash[:notice] = nil
+
+- if flash[:error]
+  %p.error= flash[:error]
+  - flash[:error] = nil

--- a/app/views/pages/contact.html.haml
+++ b/app/views/pages/contact.html.haml
@@ -1,4 +1,3 @@
-= render 'flash_notice'
 
 .row
   .span10.offset1
@@ -8,8 +7,11 @@
       %h2= t 'contact.feedback'
 
       .feedback_form
+        = render 'flash_notice'
         %p= t 'contact.feedback_text'
         = form_for :feedback, :url => send_feedback_path do |f|
+          = f.invisible_captcha :country
+
           .field
             %label= t 'contact.name'
             = f.text_field :name, required: true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,4 +44,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
 end

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+InvisibleCaptcha.setup do |config|
+  config.timestamp_enabled = !Rails.env.test?
+end

--- a/config/locales/nl_invisible_captcha.yml
+++ b/config/locales/nl_invisible_captcha.yml
@@ -1,0 +1,4 @@
+nl:
+  invisible_captcha:
+    sentence_for_humans: "Als je een mens bent, negeer dan dit veld"
+    timestamp_error_message: "Sorry, dat was te snel! Gelieve opnieuw in te dienen."

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -7,27 +7,41 @@ describe PagesController do
       ActionMailer::Base.deliveries
     end
 
-    before do
-      ActionMailer::Base.deliveries = []
-      post :send_feedback, xhr: true, params: { feedback: {
+    let(:feedback_params) do
+      {
         name: 'Schwarzenegger',
         email: 'arnold@quintel.com',
         message: "I'll be back"
-      }}
+      }
+    end
 
+    before do
+      ActionMailer::Base.deliveries = []
+      post :send_feedback, xhr: true, params: { feedback: feedback_params }
       response
     end
 
-    it 'sends an email' do
-      expect(delivered_emails.size).to eq(1)
+    context 'with valid parameters' do
+      it 'sends an email' do
+        expect(delivered_emails.size).to eq(1)
+      end
+
+      it 'mails to info@energytransitionmodel.com' do
+        expect(delivered_emails.first.to[0]).
+          to eq('info@energytransitionmodel.com')
+      end
+
+      it 'contains a message' do
+        expect(delivered_emails.first.body.raw_source).to include('ll be back')
+      end
     end
 
-    it 'mails to info@energytransitionmodel.com' do
-      expect(delivered_emails.first.to[0]).to eq('info@energytransitionmodel.com')
-    end
+    context 'with the invisible_captcha field filled in' do
+      let(:feedback_params) { super().merge(country: 'NL') }
 
-    it 'contains a message' do
-      expect(delivered_emails.first.body.raw_source).to include("ll be back")
+      it 'does not send an email' do
+        expect(delivered_emails.size).to be_zero
+      end
     end
   end
 end


### PR DESCRIPTION
This adds [the invisible_captcha gem](https://github.com/markets/invisible_captcha) in the hope of preventing spam submissions of the feedback form. I opted for this over reCAPTCHA as it doesn't require users to perform any extra steps, and doesn't send any user data to Google.

Hopefully this will be good enough.

@noracato If you're happy with this, prior to merging would you mind checking/adjusting [the translations Google came up with](https://github.com/quintel/etcentral/blob/26f0bb650b6d729242c32e39d7f0c0e3c6203a7a/config/locales/nl_invisible_captcha.yml)? TY!